### PR TITLE
Update bash script magic

### DIFF
--- a/deploy-helpers.sh
+++ b/deploy-helpers.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 # © Copyright IBM Corporation 2023, 2024
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/deploy-kafka-connect.sh
+++ b/scripts/deploy-kafka-connect.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 # © Copyright IBM Corporation 2023, 2024
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/deploy-kafka-topic.sh
+++ b/scripts/deploy-kafka-topic.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 # © Copyright IBM Corporation 2023, 2024
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/deploy-mq.sh
+++ b/scripts/deploy-mq.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 # © Copyright IBM Corporation 2023, 2024
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
bash normally uses `#!/bin/bash` for the magic start sequence; see https://tldp.org/LDP/abs/html/sha-bang.html and other pages for the Unix and Linux standard which should also work on Mac.

Previous code shows errors on Linux:
```
tdolby@IBM-PF3K066L:~/github.com/eventautomationL3$ ./deploy-helpers.sh
./deploy-helpers.sh: line 1: !/bin/bash: No such file or directory
```